### PR TITLE
Support client rendering

### DIFF
--- a/example/app/client-test/page.tsx
+++ b/example/app/client-test/page.tsx
@@ -1,0 +1,23 @@
+"use client";
+import { Textarea } from "@/lib/text-area";
+import { Suspense, startTransition, useState } from "react";
+import { experimental_CodeBlockClient as CodeBlockClient } from "react-perfect-syntax-highlighter/client";
+
+export default function Page() {
+  const [code, setCode] = useState("const x = 40 + 2;");
+  return (
+    <>
+      <Textarea
+        value={code}
+        onChange={(e) => {
+          startTransition(() => {
+            setCode(e.currentTarget.value);
+          });
+        }}
+      />
+      <Suspense>
+        <CodeBlockClient lang="tsx" theme="github-dark" code={code} />
+      </Suspense>
+    </>
+  );
+}

--- a/example/app/client-test/page.tsx
+++ b/example/app/client-test/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { Textarea } from "@/lib/text-area";
 import { Suspense, startTransition, useState } from "react";
-import { experimental_CodeBlockClient as CodeBlockClient } from "react-perfect-syntax-highlighter/client";
+import { CodeBlock } from "react-perfect-syntax-highlighter";
 
 export default function Page() {
   const [code, setCode] = useState("const x = 40 + 2;");
@@ -16,7 +16,7 @@ export default function Page() {
         }}
       />
       <Suspense>
-        <CodeBlockClient lang="tsx" theme="github-dark" code={code} />
+        <CodeBlock lang="tsx" theme="github-dark" code={code} />
       </Suspense>
     </>
   );

--- a/example/app/page.tsx
+++ b/example/app/page.tsx
@@ -2,6 +2,7 @@ import { Button } from "@/lib/button";
 import { CodeBlock } from "react-perfect-syntax-highlighter";
 import { Stack } from "@/lib/stack";
 import { Heading1, Heading2, Paragraph } from "@/lib/typography";
+import Link from "next/link";
 
 export default function Home() {
   return (
@@ -22,13 +23,19 @@ export default function Home() {
 
       <Stack space={1}>
         <Paragraph>Here's an example:</Paragraph>
-        {/* @ts-expect-error Server component */}
         <CodeBlock
           code={sampleCode}
           lang="tsx"
           theme="github-dark"
           className="overflow-x-auto p-4 rounded"
         />
+        <Paragraph>
+          Also see an example doing syntax highlighting on the client{" "}
+          <Link href="/client-test" className="underline font-bold">
+            here
+          </Link>
+          .
+        </Paragraph>
       </Stack>
 
       <section>

--- a/lib/package.json
+++ b/lib/package.json
@@ -12,6 +12,11 @@
       "types": "./dist/experimental_actions.d.ts",
       "require": "./dist/cjs/experimental_actions.js",
       "default": "./dist/experimental_actions.js"
+    },
+    "./client": {
+      "types": "./dist/codeblock-client.d.ts",
+      "require": "./dist/cjs/codeblock-client.js",
+      "default": "./dist/codeblock-client.js"
     }
   },
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -12,11 +12,6 @@
       "types": "./dist/experimental_actions.d.ts",
       "require": "./dist/cjs/experimental_actions.js",
       "default": "./dist/experimental_actions.js"
-    },
-    "./client": {
-      "types": "./dist/codeblock-client.d.ts",
-      "require": "./dist/cjs/codeblock-client.js",
-      "default": "./dist/codeblock-client.js"
     }
   },
   "scripts": {

--- a/lib/src/codeblock.tsx
+++ b/lib/src/codeblock.tsx
@@ -1,6 +1,5 @@
-import "server-only";
 import { Theme, highlight as lighterHighlight } from "@code-hike/lighter";
-import { Fragment, cache } from "react";
+import { Fragment, cache, use } from "react";
 
 export interface CodeBlockProps {
   code: string;
@@ -9,13 +8,8 @@ export interface CodeBlockProps {
   className?: string;
 }
 
-export async function CodeBlock({
-  code,
-  lang,
-  theme,
-  className,
-}: CodeBlockProps) {
-  const { lines, colors } = await highlight(code, lang, theme);
+export function CodeBlock({ code, lang, theme, className }: CodeBlockProps) {
+  const { lines, colors } = use(highlight(code, lang, theme));
 
   return (
     <pre


### PR DESCRIPTION
This PR refactors the component into a shared component, meaning it can be rendered as a server component or a client component depending on the context.

This is possible because lighter is complete isomorphic, and so is `use()`.